### PR TITLE
fix l.af_size

### DIFF
--- a/src/connected_layer.c
+++ b/src/connected_layer.c
@@ -193,7 +193,7 @@ layer make_connected_layer(int batch, int inputs, int outputs, ACTIVATION activa
 #if defined (LOWP) || defined (FPGA)
     l.workspace_size = (l.inputs*l.outputs*4 > l.outputs*l.batch*4) ? (l.inputs*l.outputs*4) : (l.outputs*l.batch*4);
     l.cf_size = (l.outputs*l.batch*4 > l.inputs*l.outputs*4) ? (l.outputs*l.batch*4) : (l.inputs*l.outputs*4);
-    l.af_size = l.batch*l.inputs*1;
+    l.af_size = l.batch*l.inputs*l.outputs;
     l.bf_size = l.batch*l.outputs*1;
     l.df_size = l.batch*l.outputs*1;
 #else


### PR DESCRIPTION
`net.af` is used to store the transposed version of `l.weights`, thus the size of `net.af` (decided by `l.af_size`) should be as large as `l.batch*l.inputs*l.outputs`.